### PR TITLE
remove || true that was erroneously causing the uniswap test to repor…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
           ROOT_PRIVATE_KEY: ${{ steps.testnode.outputs.ROOT_PRIVATE_KEY }}
           USER_1_PRIVATE_KEY: ${{ steps.accounts.outputs.ACCOUNT2_PRIVATE_KEY }}
         run: |
-          cd ./extern/fevm-uniswap-v3-core && yarn && npx hardhat --network local test || true
+          cd ./extern/fevm-uniswap-v3-core && yarn && npx hardhat --network local test
       - name: 'Run tests: OpenZeppelin'
         if: always()
         timeout-minutes: 30


### PR DESCRIPTION
|| true at the end of the run command forces the github ci to accept the uniswap test as always passing as long as it finishes within the timeout period