### PR TITLE
Update fevm-contract-tests repo to use the consensys shipyard ipc mono repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,9 +60,9 @@ jobs:
       - name: Run a testnode
         id: testnode
         run: |
-          cd $GITHUB_WORKSPACE/ipc/infra/fendermint
+          cd $GITHUB_WORKSPACE/ipc/
           export BALANCE=10000000000
-          { out=$(cargo make --makefile ./Makefile.toml testnode | tee /dev/fd/3); } 3>&1
+          { out=$(cargo make --makefile ./infra/fendermint/Makefile.toml testnode | tee /dev/fd/3); } 3>&1
           private_key=$(echo $out | sed -e 's/\(.*\)\([a-f0-9]\{64\}\)/0x\2/' | grep 0x | head -c66)
           echo "ROOT_PRIVATE_KEY=$private_key" >> "$GITHUB_OUTPUT"
           cat $GITHUB_OUTPUT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'consensus-shipyard/ipc'
+          ref: 'mikers/FendermintGenesisMinCollateral'
           submodules: 'recursive'
           path: 'ipc'
       - name: Install Node.js

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'consensus-shipyard/ipc'
-          ref: 'mikers/FendermintGenesisMinCollateral'
           submodules: 'recursive'
           path: 'ipc'
       - name: Install Node.js

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,9 @@ jobs:
       - name: Checkout Fendermint
         uses: actions/checkout@v2
         with:
-          repository: 'consensus-shipyard/fendermint'
+          repository: 'consensus-shipyard/ipc'
           submodules: 'recursive'
-          path: 'fendermint'
+          path: 'ipc'
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
@@ -60,9 +60,9 @@ jobs:
       - name: Run a testnode
         id: testnode
         run: |
-          cd $GITHUB_WORKSPACE/fendermint
+          cd $GITHUB_WORKSPACE/ipc/infra/fendermint
           export BALANCE=10000000000
-          { out=$(cargo make --makefile ./infra/Makefile.toml testnode | tee /dev/fd/3); } 3>&1
+          { out=$(cargo make --makefile ./Makefile.toml testnode | tee /dev/fd/3); } 3>&1
           private_key=$(echo $out | sed -e 's/\(.*\)\([a-f0-9]\{64\}\)/0x\2/' | grep 0x | head -c66)
           echo "ROOT_PRIVATE_KEY=$private_key" >> "$GITHUB_OUTPUT"
           cat $GITHUB_OUTPUT

--- a/tasks/create-fund-accounts.js
+++ b/tasks/create-fund-accounts.js
@@ -28,7 +28,7 @@ task("create-fund-accounts", "Create accounts and fund them with 100 coins each,
 
         if (process.env.GITHUB_ACTIONS) {
             const fs = require('fs');
-            const path = process.env.GITHUB_OUTPUT;
+            const path = process.env.GITHUB_ENV;
             const out = accounts.map((account, i) => `ACCOUNT${i + 1}_PRIVATE_KEY=${account.privateKey}`).join("\n");
             fs.appendFileSync(path, out);
         }


### PR DESCRIPTION
- switch to repository [consensus-shipyard/ipc](https://github.com/consensus-shipyard/ipc/) in the github action ci.yaml
- bugfix in `tasks/create-fund-accounts.js` to properly propagate environment variables

Before merging we will need to:
 
- [x] - have the ipc mono repo successfully run the command `cargo make --makefile ./infra/fendermint/Makefile.toml testnode` which is tracked in [this issue](https://github.com/consensus-shipyard/ipc/issues/546)
- [x] - remove the line of code from this PR `ref: 'mikers/FendermintGenesisMinCollateral'` 
- [x] - have a succesful run of the github action on ipc's main branch