### PR TITLE
remove outputFile configuration entry for gasReport

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -41,6 +41,5 @@ module.exports = {
   gasReporter: {
     enabled: true,
     noColors: true,
-    outputFile: './gasreport/gas.txt',
   }
 };


### PR DESCRIPTION
The outputFile `/gasreport/gas.txt` is creating problems because the folder gasreport does not exist. This is causing the node process to error when generating the gas report, which was still permitting the process to exit with a status code = 0 when there were errors. Also the default output location, stdout, is better for our context anyway